### PR TITLE
Replace rocm-smi with amd-smi for GPU count in CI scripts

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -20,10 +20,13 @@ set -x
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
 # If rocm-smi exists locally (it should) use it to find
 # out how many GPUs we have to test with.
-rocm-smi -i
+amd-smi list >/dev/null 2>&1
 STATUS=$?
-if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
-    TF_GPU_COUNT=$(rocm-smi -i|grep 'Device ID' |grep 'GPU' |wc -l)
+if [ $STATUS -ne 0 ]; then
+  TF_GPU_COUNT=1
+else
+  TF_GPU_COUNT=$(amd-smi list 2>/dev/null | grep -c '^GPU:')
+  [ "$TF_GPU_COUNT" -eq 0 ] && TF_GPU_COUNT=1
 fi
 if [[ $TF_GPU_COUNT -lt 4 ]]; then
     echo "Found only ${TF_GPU_COUNT} gpus, multi-gpu tests need atleast 4 gpus."

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -20,10 +20,13 @@ set -x
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
 # If rocm-smi exists locally (it should) use it to find
 # out how many GPUs we have to test with.
-rocm-smi -i
+amd-smi list >/dev/null 2>&1
 STATUS=$?
-if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
-    TF_GPU_COUNT=$(rocm-smi -i | grep 'Device ID' | grep 'GPU' | wc -l)
+if [ $STATUS -ne 0 ]; then
+  TF_GPU_COUNT=1
+else
+  TF_GPU_COUNT=$(amd-smi list 2>/dev/null | grep -c '^GPU:')
+  [ "$TF_GPU_COUNT" -eq 0 ] && TF_GPU_COUNT=1
 fi
 TF_TESTS_PER_GPU=1
 N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})


### PR DESCRIPTION
## Summary
- Replace rocm-smi GPU detection with amd-smi list in run_gpu_single.sh and run_gpu_multi.sh
- Fixes TFUT CI failures (exit 127) on hosts where rocm-smi is not available but amd-smi is present

## Test plan
- [x] Verified locally that amd-smi list correctly detects GPU count
- [ ] TFUT_SGPU CI run passes on Debian13/MI300X host

Made with [Cursor](https://cursor.com)